### PR TITLE
Fixed typo in Klutz role

### DIFF
--- a/src/roles.json
+++ b/src/roles.json
@@ -942,7 +942,7 @@
     "setup": false,
     "name": "Klutz",
     "team": "outsider",
-    "ability": "When you learn that you died, publicly choose 1 alive good player: if they are evil, your team loses."
+    "ability": "When you learn that you died, publicly choose 1 alive player: if they are evil, your team loses."
   },
   {
     "id": "eviltwin",


### PR DESCRIPTION
Klutz role previous said to choose an "alive good player" - this should just be an "alive player"