### PR TITLE
Update expired discord links

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -156,11 +156,11 @@
             <em>[N]</em>
           </li>
           <li>
-            <a href="https://discord.gg/tkWDny6" target="_blank">
+            <a href="https://discord.gg/Gd7ybwWbFk" target="_blank">
               Join Discord
             </a>
             <em>
-              <a href="https://discord.gg/tkWDny6" target="_blank">
+              <a href="https://discord.gg/Gd7ybwWbFk" target="_blank">
                 <font-awesome-icon :icon="['fab', 'discord']" />
               </a>
             </em>


### PR DESCRIPTION
I assume these used to point to the "Blood on the Clocktower (Unofficial)" server, since I see you're active in there. Please do correct if that's not the case!
These new invite links are set to never expire.