### PR TITLE
Add V hotkey for voting history

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -103,7 +103,9 @@ export default {
           this.$store.commit("toggleModal", "roles");
           break;
         case "v":
-          this.$store.commit("toggleModal", "voteHistory");
+          if (this.session.voteHistory.length) {
+            this.$store.commit("toggleModal", "voteHistory");
+          }
           break;
         case "escape":
           this.$store.commit("toggleModal");

--- a/src/App.vue
+++ b/src/App.vue
@@ -102,6 +102,9 @@ export default {
           if (this.session.isSpectator) return;
           this.$store.commit("toggleModal", "roles");
           break;
+        case "v":
+          this.$store.commit("toggleModal", "voteHistory");
+          break;
         case "escape":
           this.$store.commit("toggleModal");
       }

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -114,7 +114,7 @@
             v-if="session.voteHistory.length"
             @click="toggleModal('voteHistory')"
           >
-            Nomination history<em>[V]</em>            
+            Nomination history<em>[V]</em>
           </li>
           <li @click="leaveSession" v-if="session.sessionId">
             Leave Session

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -114,8 +114,7 @@
             v-if="session.voteHistory.length"
             @click="toggleModal('voteHistory')"
           >
-            Nomination history
-            <em><font-awesome-icon icon="hand-paper"/></em>
+            Nomination history<em>[V]</em>            
           </li>
           <li @click="leaveSession" v-if="session.sessionId">
             Leave Session


### PR DESCRIPTION
In the games my group has played recently, I've needed to refer to the nomination/vote history over and over, and I wished for a quick hotkey to toggle that window.