### PR TITLE
Fixes Issue #129 Stopping clearing all characters as story teller, clearing pronouns

### DIFF
--- a/src/store/modules/players.js
+++ b/src/store/modules/players.js
@@ -80,10 +80,11 @@ const actions = {
         return player;
       });
     } else {
-      players = state.players.map(({ name, id }) => ({
+      players = state.players.map(({ name, id, pronouns }) => ({
         ...NEWPLAYER,
         name,
-        id
+        id,
+        pronouns
       }));
       commit("setFabled", { fabled: [] });
     }


### PR DESCRIPTION

Fixes #129 Changes the logic when clearing all roles as the story teller to preserve the player pronouns