### PR TITLE
updated the send and update sockets methods for player pronouns to pa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+### Version 2.9.2
+- fix issue where a player and storyteller updating the same players pronouns at around the same time causes an infinite loop disconnecting the session.
+
+---
 ### Version 2.9.1
 - fix gamestate JSON not showing (custom) roles and failing to load states with custom scripts properly
 - fix gamestate not stripping out special characters from role.id on load

--- a/src/store/modules/players.js
+++ b/src/store/modules/players.js
@@ -102,6 +102,14 @@ const mutations = {
   set(state, players = []) {
     state.players = players;
   },
+  /**
+  The update mutation also has a property for isFromSockets
+  this property can be addded to payload object for any mutations
+  then can be used to prevent infinite loops when a property is
+  able to be set from multiple different session on websockets.
+  An example of this is in the sendPlayerPronouns and _updatePlayerPronouns
+  in socket.js.
+   */
   update(state, { player, property, value }) {
     const index = state.players.indexOf(player);
     if (index >= 0) {

--- a/src/store/socket.js
+++ b/src/store/socket.js
@@ -489,35 +489,35 @@ class LiveSession {
    * Publish a player pronouns update
    * @param player
    * @param value
+   * @param fromSockets
    */
-  sendPlayerPronouns({ player, value }) {
+  sendPlayerPronouns({ player, value, fromSockets }) {
     //send pronoun only for the seated player or storyteller
-    if (this._isSpectator && this._store.state.session.playerId !== player.id)
+    //Do not re-send pronoun data for an update that was recieved from the sockets layer
+    if (
+      fromSockets ||
+      (this._isSpectator && this._store.state.session.playerId !== player.id)
+    )
       return;
     const index = this._store.state.players.players.indexOf(player);
-    this._send("pronouns", [index, value, !this._isSpectator]);
+    this._send("pronouns", [index, value]);
   }
 
   /**
-   * Update a pronouns based on incoming data. Player only.
+   * Update a pronouns based on incoming data.
    * @param index
    * @param value
-   * @param fromSt
    * @private
    */
-  _updatePlayerPronouns([index, value, fromST]) {
+  _updatePlayerPronouns([index, value]) {
     const player = this._store.state.players.players[index];
-    if (
-      player &&
-      (fromST || this._store.state.session.playerId !== player.id) &&
-      player.pronouns !== value
-    ) {
-      this._store.commit("players/update", {
-        player,
-        property: "pronouns",
-        value
-      });
-    }
+
+    this._store.commit("players/update", {
+      player,
+      property: "pronouns",
+      value,
+      fromSockets: true
+    });
   }
 
   /**

--- a/src/store/socket.js
+++ b/src/store/socket.js
@@ -489,13 +489,13 @@ class LiveSession {
    * Publish a player pronouns update
    * @param player
    * @param value
-   * @param fromSockets
+   * @param isFromSockets
    */
-  sendPlayerPronouns({ player, value, fromSockets }) {
+  sendPlayerPronouns({ player, value, isFromSockets }) {
     //send pronoun only for the seated player or storyteller
     //Do not re-send pronoun data for an update that was recieved from the sockets layer
     if (
-      fromSockets ||
+      isFromSockets ||
       (this._isSpectator && this._store.state.session.playerId !== player.id)
     )
       return;
@@ -516,7 +516,7 @@ class LiveSession {
       player,
       property: "pronouns",
       value,
-      fromSockets: true
+      isFromSockets: true
     });
   }
 


### PR DESCRIPTION
Fixes #133

Improved the code preventing infinite loops when updating player pronouns, by now tracking through the code if an update to the pronouns came from the UI or the sockets layer.  This has simplified the code slightly and prevents the infinite loop bug coming from a race condition when the ST and player update the players pronouns close together.

It is still possible for different players to display different pronoun data for a player in the case two changes are made close together, depening on which one applies second and "wins", but it will no longer cause the infinite loop disconnecting the session.