### PR TITLE
Add option to reduce night animations to save power.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,7 +17,8 @@
       autoplay
       loop
     ></video>
-    <div class="backdrop"></div>
+    <div v-if="grimoire.isNightAnimated" class="backdrop animated"></div>
+    <div v-else class="backdrop"></div>
     <transition name="blur">
       <Intro v-if="!players.length"></Intro>
       <TownInfo v-if="players.length && !session.nomination"></TownInfo>
@@ -339,9 +340,12 @@ video#background {
     height: 100%;
     background: url("assets/clouds.png") repeat;
     background-size: 2000px auto;
-    animation: move-background 120s linear infinite;
     opacity: 0.3;
   }
+}
+
+#app > .backdrop.animated:after {
+  animation: move-background 120s linear infinite;
 }
 
 @keyframes move-background {

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -96,6 +96,16 @@
             Background image
             <em><font-awesome-icon icon="image"/></em>
           </li>
+          <li @click="toggleNightAnimated">
+            Animated night
+            <em
+              ><font-awesome-icon
+                :icon="[
+                  'fas',
+                  grimoire.isNightAnimated ? 'check-square' : 'square'
+                ]"
+            /></em>
+          </li>
           <li @click="toggleMuted">
             Mute Sounds
             <em
@@ -334,6 +344,7 @@ export default {
       "toggleMuted",
       "toggleNight",
       "toggleNightOrder",
+      "toggleNightAnimated",
       "setZoom",
       "toggleModal"
     ])

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -79,6 +79,7 @@ export default new Vuex.Store({
     grimoire: {
       isNight: false,
       isNightOrder: true,
+      isNightAnimated: true,
       isPublic: true,
       isMenuOpen: false,
       isMuted: false,
@@ -144,6 +145,7 @@ export default new Vuex.Store({
     toggleMuted: toggle("isMuted"),
     toggleMenu: toggle("isMenuOpen"),
     toggleNightOrder: toggle("isNightOrder"),
+    toggleNightAnimated: toggle("isNightAnimated"),
     toggleNight: toggle("isNight"),
     toggleGrimoire: toggle("isPublic"),
     toggleImageOptIn: toggle("isImageOptIn"),


### PR DESCRIPTION
During a 15-hour marathon session yesterday, I was finding that (at times) my browser was consuming so much power that the battery actually couldn't charge.  There were times where I was plugged into AC power, and yet I was still at <20% battery _and dropping_.

Did some testing today and discovered that the culprit is the animated night backdrop.  When it's on-screen, the browser spends large amounts of CPU/GPU power rendering it.  (The amount used depends on how many players and reminder tokens are on screen, which suggests the main source of usage is re-rendering all those items every frame.)

With a lot of tokens on screen, disabling the animation reduces the CPU & GPU usage of the "Chrome Helper (GPU)" process from upwards of 90% to under 1% on my 2019 Macbook Pro, and the system cools down, fans spin down, etc.  On my Windows gaming system, disabling the animation reduces GPU usage from 15% to <1% as well.  (Using 15% of an RTX 3090 card is fairly significant. 😅)

I've never worked with Vue, but it seemed relatively trivial to make the animation conditional on a boolean option.  Obviously I've left it enabled by default, because the effect is indeed quite lovely, but if players are finding their laptops are toasting their laps during some of the longer nights, they may appreciate being able to turn that off.