### PR TITLE
add ST character reveal for player tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Release Notes
 
+- add ST character reveal, per player
+
 ### Version 2.12.0
 - tweak reference sheet to better fit screen in single column layout
 - add warning icon overlay for setup roles on character assignment modal

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -128,6 +128,10 @@
               <font-awesome-icon icon="hand-point-right" />
               Nomination
             </li>
+            <li @click="revealPlayer(player)">
+              <font-awesome-icon icon="satellite-dish" />
+              Reveal role to all
+            </li>
             <li @click="movePlayer()">
               <font-awesome-icon icon="redo-alt" />
               Move player
@@ -295,6 +299,9 @@ export default {
       if (closeMenu) {
         this.isMenuOpen = false;
       }
+    },
+    revealPlayer() {
+      this.$emit("trigger", ["revealPlayer"]);
     },
     removePlayer() {
       this.isMenuOpen = false;

--- a/src/components/TownSquare.vue
+++ b/src/components/TownSquare.vue
@@ -161,6 +161,17 @@ export default {
         this.$store.commit("players/remove", playerIndex);
       }
     },
+    revealPlayer(playerIndex) {
+      if (!this.session.isRevealPlayerOK) {
+        if (
+          !confirm(
+            `Do you really want to reveal this players role to ALL other players?\n\nYou won't be asked to confirm again this game.`
+          )
+        )
+          return;
+      }
+      this.$store.commit("session/revealPlayer", playerIndex);
+    },
     swapPlayer(from, to) {
       if (to === undefined) {
         this.cancel();

--- a/src/main.js
+++ b/src/main.js
@@ -33,6 +33,7 @@ const faIcons = [
   "Question",
   "Random",
   "RedoAlt",
+  "SatelliteDish",
   "SearchMinus",
   "SearchPlus",
   "Square",

--- a/src/store/modules/session.js
+++ b/src/store/modules/session.js
@@ -25,7 +25,8 @@ const state = () => ({
   votingSpeed: 3000,
   isVoteInProgress: false,
   voteHistory: [],
-  isRolesDistributed: false
+  isRolesDistributed: false,
+  isRevealPlayerOK: false
 });
 
 const getters = {};
@@ -47,6 +48,9 @@ const mutations = {
   setVoteInProgress: set("isVoteInProgress"),
   claimSeat: set("claimedSeat"),
   distributeRoles: set("isRolesDistributed"),
+  revealPlayer(state) {
+	  state.isRevealPlayerOK = true;
+  },
   setSessionId(state, sessionId) {
     state.sessionId = sessionId
       .toLocaleLowerCase()

--- a/src/store/modules/session.js
+++ b/src/store/modules/session.js
@@ -49,7 +49,7 @@ const mutations = {
   claimSeat: set("claimedSeat"),
   distributeRoles: set("isRolesDistributed"),
   revealPlayer(state) {
-	  state.isRevealPlayerOK = true;
+    state.isRevealPlayerOK = true;
   },
   setSessionId(state, sessionId) {
     state.sessionId = sessionId

--- a/src/store/socket.js
+++ b/src/store/socket.js
@@ -634,11 +634,12 @@ class LiveSession {
   }
 
   /**
-   * Distribute player roles to all seated players in a direct message.
+   * Distribute player roles to all seated players in a direct message. ST only
    * This will be split server side so that each player only receives their own (sub)message.
    */
   distributeRoles() {
     if (this._isSpectator) return;
+	this._store.state.session.isRevealPlayerOK = false;
     const message = {};
     this._store.state.players.players.forEach((player, index) => {
       if (player.id && player.role) {
@@ -650,6 +651,19 @@ class LiveSession {
     });
     if (Object.keys(message).length) {
       this._send("direct", message);
+    }
+  }
+
+  /**
+   * Announce a single players role to all other players. ST only
+   * @param playerIndex
+   */
+  revealPlayer(index) {
+    if (this._isSpectator) return;
+    const player = this._store.state.players.players[index];
+    if (player && player.role) {
+      const message = { index, property: "role", value: player.role.id };
+      this._send("player", message);
     }
   }
 
@@ -821,6 +835,9 @@ export default store => {
         if (payload) {
           session.distributeRoles();
         }
+        break;
+      case "session/revealPlayer":
+        session.revealPlayer(payload);
         break;
       case "session/nomination":
         session.nomination(payload);

--- a/src/store/socket.js
+++ b/src/store/socket.js
@@ -639,7 +639,7 @@ class LiveSession {
    */
   distributeRoles() {
     if (this._isSpectator) return;
-	this._store.state.session.isRevealPlayerOK = false;
+    this._store.state.session.isRevealPlayerOK = false;
     const message = {};
     this._store.state.players.players.forEach((player, index) => {
       if (player.id && player.role) {


### PR DESCRIPTION
![Untitled](https://user-images.githubusercontent.com/14160941/116857890-71d42d80-abf5-11eb-8544-c1788178ac9a.png)

A pop-up is sent to ask if this is really intended. 
If the ST has already replied with a yes (within the same game) the pop-up is not sent again.

In https://github.com/bra1n/townsquare/pull/160 I've moved the "nomination" menu item downwards, because its the most commonly used - with that afaics "reveal" is not easily misclicked.

Only the role token is revealed, so any drunk/marionette/etc reminder tokens wouldn't be sent / overwritten. This might be best, since it should always be in tandem with the ST talking & many players write custom reminder tokens, but I'm not sure - thoughts? rel #143 

Basically fixes #116
