### PR TITLE
Revert Mezepheles to Mephit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+### Version 2.15.1
+- fix Mephit not showing up on scripts
+
+---
+
 ### Version 2.15.0
 - clean up transparent portions of icons
 - add Magician & LLeech to list of available characters

--- a/src/roles.json
+++ b/src/roles.json
@@ -1437,8 +1437,8 @@
     "ability": "If you publicly claim to be the Goblin when nominated & are executed that day, your team wins."
   },
   {
-    "id": "mezepheles",
-    "name": "Mezepheles",
+    "id": "mephit",
+    "name": "Mephit",
     "edition": "",
     "team": "minion",
     "firstNight": 24,


### PR DESCRIPTION
Reverted the name & ID of Mezepheles back to Mephit, as requested by bra1n on Discord.