### PR TITLE
add players by comma separated list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release Notes
 
 ### Version 2.15.3
+- add Add Player by comma separated list
+
+### Version 2.15.3
 - add Huntsman/Damsel, Noble, Al-Hadikhia to list of available characters
 
 ### Version 2.15.2

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -118,9 +118,7 @@
           <li class="headline" v-if="session.sessionId">
             {{ session.isSpectator ? "Playing" : "Hosting" }}
           </li>
-          <li class="headline" v-else>
-            Live Session
-          </li>
+          <li class="headline" v-else>Live Session</li>
           <template v-if="!session.sessionId">
             <li @click="hostSession">Host (Storyteller)<em>[H]</em></li>
             <li @click="joinSession">Join (Player)<em>[J]</em></li>
@@ -155,6 +153,9 @@
           <!-- Users -->
           <li class="headline">Players</li>
           <li @click="addPlayer" v-if="players.length < 20">Add<em>[A]</em></li>
+          <li @click="addPlayerList" v-if="players.length < 20">
+            Add (List)<em>[A]</em>
+          </li>
           <li @click="randomizeSeatings" v-if="players.length > 2">
             Randomize
             <em><font-awesome-icon icon="dice"/></em>
@@ -317,6 +318,22 @@ export default {
       if (name) {
         this.$store.commit("players/add", name);
       }
+    },
+    addPlayerList() {
+      if (this.session.isSpectator) return;
+      if (confirm("This will clear all players. Are you sure you want to remove all players?")) {
+        // abort vote if in progress
+        if (this.session.nomination) {
+          this.$store.commit("session/nomination");
+        }
+        this.$store.commit("players/clear");
+        const names = prompt("Player names (separated by commas)");
+        if (names) {
+          names.split(',').map(name => {
+            this.$store.commit("players/add", name);
+          })
+        }
+      }      
     },
     randomizeSeatings() {
       if (this.session.isSpectator) return;

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -321,7 +321,11 @@ export default {
     },
     addPlayerList() {
       if (this.session.isSpectator) return;
-      if (confirm("This will clear all players. Are you sure you want to remove all players?")) {
+      if (
+        confirm(
+          "This will clear all players. Are you sure you want to do this?"
+        )
+      ) {
         // abort vote if in progress
         if (this.session.nomination) {
           this.$store.commit("session/nomination");
@@ -329,11 +333,11 @@ export default {
         this.$store.commit("players/clear");
         const names = prompt("Player names (separated by commas)");
         if (names) {
-          names.split(',').map(name => {
+          names.split(",").map(name => {
             this.$store.commit("players/add", name);
-          })
+          });
         }
-      }      
+      }
     },
     randomizeSeatings() {
       if (this.session.isSpectator) return;


### PR DESCRIPTION
Created for FR #212 

The PR adds a new button in the player menu that clears the player list, then adds players from a comma separate list. 

