### PR TITLE
Add a search function to the role modal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Version 2.15.3
 - add Huntsman/Damsel, Noble, Al-Hadikhia, Golem, Fearmonger to list of available characters
+- add a search function to the role modal
 
 ### Version 2.15.2
 - added mobile web application support


### PR DESCRIPTION
When assigning a role to a player, it is now possible to type a case-
and whitespace-insensitive prefix of it to quickly find the desired
role. Pressing Enter will set the role, if the query is specific enough
to have a unique match.