### PR TITLE
Add static hover target to prevent add reminder token flickering (fix #153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Version 2.15.3
 - add Huntsman/Damsel, Noble, Al-Hadikhia, Golem, Fearmonger, Puzzlemaster, Alchemist, Engineer, Riot, Psychopath, Atheist, Nightwatchman to list of available characters
 - fixed game state JSON not handling custom Fabled correctly
+- fixed flickering of add reminder token
 
 ### Version 2.15.2
 - added mobile web application support

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -200,6 +200,7 @@
     <div class="reminder add" @click="$emit('trigger', ['openReminderModal'])">
       <span class="icon"></span>
     </div>
+    <div class="reminderHoverTarget"></div>
   </li>
 </template>
 
@@ -927,6 +928,19 @@ li.move:not(.from) .player .overlay svg.move {
     opacity: 1;
   }
 }
+
+.circle .reminderHoverTarget {
+  opacity: 0;
+  width: calc(50% + 8px);
+  padding-top: calc(50% + 38px);
+  margin-top: calc(-25% - 33px);
+  margin-left: calc(-25% - 1px);
+  border-radius: 0 0 999px 999px;
+  pointer-events: auto;
+  transform: none !important;
+  z-index: -1;
+}
+
 .circle li:hover .reminder.add {
   opacity: 1;
   top: 0;


### PR DESCRIPTION
Added a static hover target under the add reminder icon to prevent it flickering when the cursor is on the inner edge of the token (fix for #153).

The hover target covers the full area of the add reminder token animation.
![image](https://user-images.githubusercontent.com/23328388/161424650-7e310450-5996-427f-9177-d07f929ee1e7.png)
![image](https://user-images.githubusercontent.com/23328388/161425080-7b71347c-e282-4941-a394-f11c276d6e03.png)
