### PR TITLE
FIX #220 - Players marked as executed should have the mark follow them on player swaps and seat moves

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,6 +2,7 @@ import Vue from "vue";
 import Vuex from "vuex";
 import persistence from "./persistence";
 import socket from "./socket";
+import subscriptions from "./subscriptions";
 import players from "./modules/players";
 import session from "./modules/session";
 import editionJSON from "../editions.json";
@@ -262,5 +263,5 @@ export default new Vuex.Store({
       state.modals.edition = false;
     }
   },
-  plugins: [persistence, socket]
+  plugins: [persistence, socket, subscriptions]
 });

--- a/src/store/subscriptions.js
+++ b/src/store/subscriptions.js
@@ -1,0 +1,35 @@
+// Subscription to handle players moving/swapping when marked for execution
+
+module.exports = store => {
+  const handlePlayersMove = (mutation, state) => {
+    const fromPlayerIndex = mutation.payload[0];
+    if (fromPlayerIndex === state.session.markedPlayer) {
+      store.commit("session/setMarkedPlayer", mutation.payload[1]);
+    }
+  };
+
+  const handlePlayersSwap = (mutation, state) => {
+    const fromPlayerIndex = mutation.payload[0];
+    if (fromPlayerIndex === state.session.markedPlayer) {
+      store.commit("session/setMarkedPlayer", mutation.payload[1]);
+      return;
+    }
+
+    const toPlayerIndex = mutation.payload[1];
+    if (toPlayerIndex === state.session.markedPlayer) {
+      store.commit("session/setMarkedPlayer", mutation.payload[0]);
+      return;
+    }
+  };
+
+  store.subscribe((mutation, state) => {
+    switch (mutation.type) {
+      case "players/move":
+        handlePlayersMove(mutation, state);
+        break;
+      case "players/swap":
+        handlePlayersSwap(mutation, state);
+        break;
+    }
+  });
+};


### PR DESCRIPTION
* added a subscription that watches when a player moves or swaps and will dispatch the setMarkedPlayer mutation if they should be.

