### PR TITLE
Remember the players pronouns when claiming seat

### DIFF
--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -259,6 +259,7 @@ export default {
       const pronouns = prompt("Player pronouns", this.player.pronouns);
       //Only update pronouns if not null (prompt was not cancelled)
       if (pronouns !== null) {
+        localStorage.setItem("pronouns", pronouns);
         this.updatePlayer("pronouns", pronouns, true);
       }
     },

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -333,6 +333,10 @@ export default {
     claimSeat() {
       this.isMenuOpen = false;
       this.$emit("trigger", ["claimSeat"]);
+      const savedPronouns = localStorage.getItem("pronouns");
+      if (savedPronouns) {
+        this.updatePlayer("pronouns", savedPronouns);
+      }
     },
     /**
      * Allow the ST to override a locked vote.

--- a/src/store/socket.js
+++ b/src/store/socket.js
@@ -627,14 +627,18 @@ class LiveSession {
    */
   _updateSeat([index, value]) {
     if (this._isSpectator) return;
-    const property = "id";
     const players = this._store.state.players.players;
     // remove previous seat
     const oldIndex = players.findIndex(({ id }) => id === value);
     if (oldIndex >= 0 && oldIndex !== index) {
       this._store.commit("players/update", {
         player: players[oldIndex],
-        property,
+        property: "id",
+        value: ""
+      });
+      this._store.commit("players/update", {
+        player: players[oldIndex],
+        property: "pronouns",
         value: ""
       });
     }
@@ -642,7 +646,7 @@ class LiveSession {
     if (index >= 0) {
       const player = players[index];
       if (!player) return;
-      this._store.commit("players/update", { player, property, value });
+      this._store.commit("players/update", { player, property: "id", value });
     }
     // update player session list as if this was a ping
     this._handlePing([true, value, 0]);


### PR DESCRIPTION
stores pronouns in local storage and when claiming a seat they will automatically be applied.

This preference is set when changing pronouns, this causes a minor "bug" that if a story teller changes someone elses pronouns (which they can do) then it will save that as their own preference. Unsure how much this happens so leaving it in for now but if we really want to avoid this I can do a few things (either add a check box or check if user is storyteller before saving preference)

Have also made it so when leaving a seat the pronouns are removed(otherwise if a user hops between seats they would overwrite them all